### PR TITLE
fix: safari flex gap

### DIFF
--- a/packages/web/src/components/profile/FollowersInfo.tsx
+++ b/packages/web/src/components/profile/FollowersInfo.tsx
@@ -17,8 +17,8 @@ export const FollowersInfo: React.FC<Props> = ({
     <div
       className={
         size === 'large'
-          ? 'mt-8 flex bg-gray-800 rounded-2xl py-4 justify-center gap-8'
-          : 'mt-6 flex justify-center gap-12 md:hidden'
+          ? 'mt-8 flex bg-gray-800 rounded-2xl py-4 justify-center gap-8 space-x-2 '
+          : 'mt-6 flex justify-center gap-8 space-x-2 md:hidden'
       }
     >
       <div className="flex flex-col text-center leading-4">


### PR DESCRIPTION
Adjusted gap-12 property with gap-8 and added space-x-2 property which is supported on multiple browsers.