### PR TITLE
fix: safari flex layout

### DIFF
--- a/packages/web/src/pages/index.tsx
+++ b/packages/web/src/pages/index.tsx
@@ -80,7 +80,7 @@ const HomePage: React.FC<IndexPageProps> = ({ vars }) => {
         </Modal>
         <div className="z-10 relative px-6 grid grid-cols-1 lg:grid-cols-three gap-16">
           <div className="hidden lg:flex flex-col flex-1 sticky top-28 h-px">
-            <div className="w-full flex flex-col py-6 px-8 bg-gray-800 rounded-2xl">
+            <div className=" flex-shrink-0 w-full flex flex-col py-6 px-8 bg-gray-800 rounded-2xl">
               {currentUserLoading || (
                 <>
                   <Link
@@ -94,8 +94,8 @@ const HomePage: React.FC<IndexPageProps> = ({ vars }) => {
                           className="w-14 h-14 rounded-full"
                         />
                       ) : (
-                        <div className="w-14 h-14 rounded-full bg-gray-600" />
-                      )}
+                          <div className="w-14 h-14 rounded-full bg-gray-600" />
+                        )}
                       <div>
                         <p className="font-bold text-xl">
                           {user ? user.name : 'Alex'}
@@ -125,7 +125,7 @@ const HomePage: React.FC<IndexPageProps> = ({ vars }) => {
               )}
             </div>
             <Sidebar title="Friends Activity">
-              <div className="mt-6 flex flex-col space-y-4">
+              <div className="flex-shrink-0 mt-6 flex flex-col space-y-4">
                 <FriendActivity
                   name="Sam Jakob"
                   activity={['Playing', 'Visual Studio Code']}
@@ -175,8 +175,8 @@ const HomePage: React.FC<IndexPageProps> = ({ vars }) => {
               //<div key={index}>{JSON.stringify(post)}</div>
             ))}
           </div>
-          <div className="hidden lg:flex flex-col flex-1 sticky top-28 h-px">
-            <div className="w-full flex flex-col items-center">
+          <div className="flex-shrink-0 hidden lg:flex flex-col flex-1 sticky top-28 h-px">
+            <div className="flex-shrink-0 w-full flex flex-col items-center">
               <div className="flex flex-col items-center">
                 <h3>Something on your mind?</h3>
                 <Button

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
     '../ui/src/**/*.tsx',
   ],
   theme: {
+     flexShrink: {
+        '0': 0,
+      },
     fontFamily: {
       sans: [
         'Inter',


### PR DESCRIPTION
Added tailwind property "flex-shrink-0" in tailwind.config.js file to prevent flex items from over shrinking, and added flex-shrink property accordingly. 

IMPORTANT: When running yarn build I get an error "unbounded argument #0". I not sure if this is of concern.