### PR TITLE
feat: Added Connections Entity

### DIFF
--- a/packages/api/src/entities/Connection.ts
+++ b/packages/api/src/entities/Connection.ts
@@ -1,0 +1,22 @@
+import {
+  BaseEntity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinTable,
+} from 'typeorm';
+import User from './User';
+import { BCEntity, BCField } from '@root/bot-client-gen';
+import { Field, ID, ObjectType } from 'type-graphql';
+export default class Connection extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid') id: string;
+  @Column() token: string;
+  @Column() refreshToken: string;
+
+  /*@Field(() => User)
+  @ManyToOne(() => User, (user) => user.connections)
+  @BCField({ type: 'User' })
+  user: Promise<User>;*/
+
+  @Column() connectionMethod: String;
+}

--- a/packages/api/src/entities/Connection.ts
+++ b/packages/api/src/entities/Connection.ts
@@ -9,14 +9,19 @@ import User from './User';
 import { BCEntity, BCField } from '@root/bot-client-gen';
 import { Field, ID, ObjectType } from 'type-graphql';
 export default class Connection extends BaseEntity {
-  @PrimaryGeneratedColumn('uuid') id: string;
-  @Column() token: string;
-  @Column() refreshToken: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-  /*@Field(() => User)
+  @Column()
+  token: string;
+
+  @Column()
+  refreshToken: string;
+
+  /* @Field(() => User)
   @ManyToOne(() => User, (user) => user.connections)
   @BCField({ type: 'User' })
-  user: Promise<User>;*/
+  user: Promise<User>; */
 
   @Column() connectionMethod: String;
 }

--- a/packages/api/src/entities/User.ts
+++ b/packages/api/src/entities/User.ts
@@ -81,7 +81,7 @@ export default class User extends BaseEntity {
   /*@BCField({ type: 'Connection[]' })
   @OneToMany(() => Connection, (connection) => connection.user)
   @Column({ nullable: true })
-  connections: Connection; */
+  connections: Promise<Connection[]>; */
   @Column('simple-array')
   @Field(() => [Role])
   @BCField({ type: 'Role[]' })

--- a/packages/api/src/entities/User.ts
+++ b/packages/api/src/entities/User.ts
@@ -19,6 +19,7 @@ import Notification from './Notification';
 import { RelationalPagination } from '@utils/RelationalPagination';
 import { BCEntity, BCField } from '@root/bot-client-gen';
 import { PublicField } from '@utils/PublicField';
+import Connection from './Connection';
 
 @ObjectType()
 @Entity()
@@ -77,6 +78,10 @@ export default class User extends BaseEntity {
   @PublicField()
   verified: boolean;
 
+  /*@BCField({ type: 'Connection[]' })
+  @OneToMany(() => Connection, (connection) => connection.user)
+  @Column({ nullable: true })
+  connections: Connection; */
   @Column('simple-array')
   @Field(() => [Role])
   @BCField({ type: 'Role[]' })

--- a/packages/api/src/entities/User.ts
+++ b/packages/api/src/entities/User.ts
@@ -78,10 +78,11 @@ export default class User extends BaseEntity {
   @PublicField()
   verified: boolean;
 
-  /*@BCField({ type: 'Connection[]' })
+  /* @BCField({ type: 'Connection[]' })
   @OneToMany(() => Connection, (connection) => connection.user)
   @Column({ nullable: true })
   connections: Promise<Connection[]>; */
+
   @Column('simple-array')
   @Field(() => [Role])
   @BCField({ type: 'Role[]' })

--- a/packages/ui/src/components/profile/FollowersInfo.tsx
+++ b/packages/ui/src/components/profile/FollowersInfo.tsx
@@ -17,8 +17,8 @@ export const FollowersInfo: React.FC<Props> = ({
     <div
       className={
         size === 'large'
-          ? 'mt-8 flex bg-gray-800 rounded-2xl py-4 justify-center gap-8'
-          : 'mt-6 flex justify-center gap-12 md:hidden'
+          ? 'mt-8 flex bg-gray-800 rounded-2xl py-4 justify-center gap-8 space-x-2'
+          : 'mt-6 flex justify-center gap-8 md:hidden space-x-2'
       }
     >
       <div className="flex flex-col text-center leading-4">


### PR DESCRIPTION
**Description:**
Added a Connection Entity to store multiple connections for each user and to use the stored tokens to handle API request like that of Spotify.ts file. 
Added a column in User Entity for this relationship with the Connection Entity.

**Related Issue (if applicable):**
Currently, the relationship in  Connection.ts and User.ts  is **comment blocked temporarily until the following error is fixed**:
"unhandledpromiserejectionwarning: error: entity metadata for user#connections was not found. check if you specified a correct entity object and if it's connected in the connection options. "

This error is reproduced from running the yarn dev command once removing the comment blocked code. 
I tried refreshing typescript server, running yarn build api command but still got the error.


