### PR TITLE
fix: safari flex gap

### DIFF
--- a/packages/ui/src/components/profile/FollowersInfo.tsx
+++ b/packages/ui/src/components/profile/FollowersInfo.tsx
@@ -17,8 +17,8 @@ export const FollowersInfo: React.FC<Props> = ({
     <div
       className={
         size === 'large'
-          ? 'mt-8 flex bg-gray-800 rounded-2xl py-4 justify-center gap-8'
-          : 'mt-6 flex justify-center gap-12 md:hidden'
+          ? 'mt-8 flex bg-gray-800 rounded-2xl py-4 justify-center gap-8 space-x-2'
+          : 'mt-6 flex justify-center gap-8 md:hidden space-x-2'
       }
     >
       <div className="flex flex-col text-center leading-4">


### PR DESCRIPTION
**Description:**
Pull request re-attempt since previous pull request was not merged.

Added space-x property that is supported by multiple browser including safari. Also changed gap-12 to gap-8 on small screen to reduce the extra-long whitespace that is created with the space-x property. Now UI looks same on safari and chrome.

<img width="928" alt="Screen Shot 2021-06-04 at 11 03 54 AM" src="https://user-images.githubusercontent.com/42325851/120822612-98eb8b00-c524-11eb-8c0c-37ab3d072ec0.png">

On left is what chrome looks like and right is safari with the new changes.

