### PR TITLE
Fix SQLite Feed Error & CustomLink Tweaks

### DIFF
--- a/packages/api/src/resolvers/post/feed/FeedSort.resolver.ts
+++ b/packages/api/src/resolvers/post/feed/FeedSort.resolver.ts
@@ -9,7 +9,7 @@ export class DeletePostResolver {
     @Arg('offset') offset: number
   ) {
     return await Post.createQueryBuilder('post')
-      .addSelect('COUNT(likers.*) as likes')
+      .addSelect('COUNT(likers.id) as likes')
       .leftJoin('post.likers', 'likers')
       // .leftJoin('post.dislikers', 'dislikers')
       .groupBy('post.id')

--- a/packages/ui/src/components/navbar/DropdownItem.tsx
+++ b/packages/ui/src/components/navbar/DropdownItem.tsx
@@ -1,5 +1,4 @@
 import React, { MouseEventHandler } from 'react';
-import { CustomLink } from '../../providers/CustomLink';
 
 interface DropdownItemProps {
   name: string;
@@ -17,9 +16,9 @@ export const DropdownItem: React.FC<DropdownItemProps> = (props) => {
       onClick={props.onClick}
     >
       <Icon />
-      <CustomLink href={props.href} className="font-medium text-white">
+      <p className="font-medium text-white">
         {props.name}
-      </CustomLink>
+      </p>
     </div>
   );
 };

--- a/packages/ui/src/components/navbar/Navbar.tsx
+++ b/packages/ui/src/components/navbar/Navbar.tsx
@@ -1,21 +1,22 @@
-import { NavItem } from '../navbar/NavItem';
-import { DropdownItem } from '../navbar/DropdownItem';
-import { Button } from '../shared/Button';
 import {
   Bell,
   Friends,
   Home,
-  Search,
-  Saved,
-  Topics,
-  Profile as ProfileIcon,
   Logout as LogoutIcon,
+  Profile as ProfileIcon,
+  Saved,
+  Search,
+  Topics,
 } from '../../icons';
 import React, { useRef, useState } from 'react';
-import useOnClickOutside from '../../hooks/useOnClickOutside';
+
+import { Button } from '../shared/Button';
+import { CustomLink } from '../../providers/CustomLink';
+import { DropdownItem } from '../navbar/DropdownItem';
+import { NavItem } from '../navbar/NavItem';
 import { User } from '@oasis-sh/react-gql';
 import { redirect } from '../../utils/redirect';
-import { CustomLink } from '../../providers/CustomLink';
+import useOnClickOutside from '../../hooks/useOnClickOutside';
 
 interface INavbarProps {
   user?: User | undefined;

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -1,14 +1,15 @@
-import { AppProps } from 'next/app';
 import '../styles/globals.css';
-import Head from 'next/head';
+
 import { ApolloProvider } from '@apollo/client';
-import { useApollo } from '@lib/common/apolloClient';
+import { AppProps } from 'next/app';
 import { AuthProvider } from '@shared/AuthProvider';
+import Head from 'next/head';
+import Link from 'next/link';
+import { LinkProvider } from '@oasis-sh/ui';
+import { RuntimesProvider } from '@shared/PistonRuntimesProvider';
 import { SEO } from '@shared/SEO';
 import { initSentry } from '@utils/sentry';
-import { RuntimesProvider } from '@shared/PistonRuntimesProvider';
-import { LinkProvider } from '@oasis-sh/ui';
-import Link from 'next/link';
+import { useApollo } from '@lib/common/apolloClient';
 
 initSentry();
 export default function App({
@@ -24,7 +25,7 @@ export default function App({
           <LinkProvider
             link={(children, href, className) => (
               <div className={`inline cursor-pointer ${className}`}>
-                <Link href={href ?? '#'}>{children}</Link>
+                <Link href={href ?? '#'} passHref><a>{children}</a></Link>
               </div>
             )}
           >


### PR DESCRIPTION
**Description:**
SQLite on local environments didn't load the feed properly due to a misused wildcard. Changing to sort the feed by id resolves the issue.

Next/Link requires a wrapping <a> for a11y, and passHref to deal with overwrapped components.
[Custom Component Wrapping An A Tag - Next.js Docs](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag)
